### PR TITLE
Add data_cache storage disk

### DIFF
--- a/app/Console/Commands/OverlayCron.php
+++ b/app/Console/Commands/OverlayCron.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use App\Jobs\RenderOverlay;
+use Illuminate\Support\Facades\Storage;
 
 class OverlayCron extends Command
 {
@@ -44,10 +45,11 @@ class OverlayCron extends Command
         RenderOverlay::dispatchSync(1, 1, 1);
 
         for ($i = 6; $i < 11; $i++) {
-            $files = glob(base_path('lb_json/l_' . $i . '*.packed'));
-            $files = array_filter($files, fn($item) => filesize($item) > 9000000);
+            $pattern = Storage::disk('data_cache')->path('l_' . $i . '*.packed');
+            $files = glob($pattern);
+            $files = array_filter($files, fn($item) => Storage::disk('data_cache')->size(basename($item)) > 9000000);
             foreach ($files as $file) {
-                preg_match('~/lb_json/l_(?<zoom>(\\d+)).(?<x>(\\d+)).(?<y>(\\d+)).packed~', $file, $m);
+                preg_match('/l_(?<zoom>\d+)\.(?<x>\d+)\.(?<y>\d+)\.packed/', basename($file), $m);
                 $renderChilds((int)$m['zoom'], (int)$m['x'], (int)$m['y']);
             }
         }

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Jobs\RenderOverlay;
 use App\Services\MapRenderer;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 
 class MapController extends Controller
 {
@@ -13,14 +14,14 @@ class MapController extends Controller
         $pzoom = $z;
         $px = $x;
         $py = $y;
-        $parent = base_path("lb_json/l_{$pzoom}.{$px}.{$py}.packed");
-        while ($pzoom > 6 && !file_exists($parent)) {
+        $parent = "l_{$pzoom}.{$px}.{$py}.packed";
+        while ($pzoom > 6 && !Storage::disk('data_cache')->exists($parent)) {
             $pzoom -= 1;
             $px = floor($px / 2);
             $py = floor($py / 2);
-            $parent = base_path("lb_json/l_{$pzoom}.{$px}.{$py}.packed");
+            $parent = "l_{$pzoom}.{$px}.{$py}.packed";
         }
-        if (filesize(base_path("lb_json/l_{$pzoom}.{$px}.{$py}.packed")) < 13718638) {
+        if (Storage::disk('data_cache')->size($parent) < 13718638) {
             RenderOverlay::dispatchSync($z, $x, $y);
             $path = base_path("lb_overlay/$z/$x/$y.png");
             return response()->file($path, [

--- a/app/Services/LBRoads.php
+++ b/app/Services/LBRoads.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class LBRoads{
 	public function create_o5m($zoom,$x,$y){
@@ -131,9 +132,9 @@ class LBRoads{
 				}
 			}
 		}
-		$path=base_path('lb_json/l_'.$zoom.'.'.$x.'.'.$y.'.packed');
-		file_put_contents($path,$this->lines2file($lines));
-		return $lines;
+               $file = 'l_'.$zoom.'.'.$x.'.'.$y.'.packed';
+               Storage::disk('data_cache')->put($file, $this->lines2file($lines));
+               return $lines;
 	}
 	public function file2lines($content){
 		$lbroads = $this->getLbroadsMapping();
@@ -200,14 +201,14 @@ class LBRoads{
 		$compressed=gzcompress($packed,9);
 		return $compressed;
 	}
-	public function get_lines($zoom,$x,$y){
-		$path=base_path('lb_json/l_'.$zoom.'.'.$x.'.'.$y.'.packed');
-		if(file_exists($path)){
-			return $this->file2lines(file_get_contents($path));
-		}
-		if($zoom>7){
-			return $this->parse_parent_lines($zoom,$x,$y);
-		}
+       public function get_lines($zoom,$x,$y){
+               $file = 'l_'.$zoom.'.'.$x.'.'.$y.'.packed';
+               if(Storage::disk('data_cache')->exists($file)){
+                       return $this->file2lines(Storage::disk('data_cache')->get($file));
+               }
+               if($zoom>7){
+                       return $this->parse_parent_lines($zoom,$x,$y);
+               }
 		
 		$elements=$this->get_converted($zoom,$x,$y);
 		
@@ -233,7 +234,7 @@ class LBRoads{
 			}
 		}
 //		if(php_sapi_name()=='cli'){var_dump('filtered_lines|time:'.time());}
-		file_put_contents($path,$this->lines2file($lines));
-		return $lines;	
-	}
+               Storage::disk('data_cache')->put($file,$this->lines2file($lines));
+               return $lines;
+       }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -47,6 +47,13 @@ return [
             'report' => false,
         ],
 
+        'data_cache' => [
+            'driver' => 'local',
+            'root' => storage_path('app/data_cache'),
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,4 +1,5 @@
 *
 !private/
 !public/
+!data_cache/
 !.gitignore

--- a/storage/app/data_cache/.gitignore
+++ b/storage/app/data_cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add `data_cache` disk to filesystem config
- keep `data_cache` folder in repo
- store `.packed` files under `data_cache`
- use Storage facade for `data_cache` operations

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860482496f8832bb4b6a2ed5a3ed274