### PR TITLE
Prevent concurrent osmconvert runs

### DIFF
--- a/app/Services/LBRoads.php
+++ b/app/Services/LBRoads.php
@@ -4,12 +4,18 @@ namespace App\Services;
 
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Cache;
 
 class LBRoads{
        private function runOsmconvert(string $filename, string $params, bool $returnOutput = true)
        {
                $command = 'osmconvert ' . $filename . ' ' . $params;
-               $result = Process::run($command);
+
+               $lockName = 'osmconvert:' . md5($filename);
+
+               $result = Cache::lock($lockName, 600)->block(0, function () use ($command) {
+                       return Process::run($command);
+               });
 
                return $returnOutput ? $result->output() : '';
        }


### PR DESCRIPTION
## Summary
- scope cache lock to filename when running osmconvert
- throw exception immediately if lock cannot be acquired

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861af6bab50832b94232c705c11266c